### PR TITLE
fix NPE

### DIFF
--- a/portlets/caldav-portlet/docroot/WEB-INF/service/it/smc/calendar/sync/caldav/CalDAVRequestThreadLocal.java
+++ b/portlets/caldav-portlet/docroot/WEB-INF/service/it/smc/calendar/sync/caldav/CalDAVRequestThreadLocal.java
@@ -33,8 +33,12 @@ public class CalDAVRequestThreadLocal {
 	public static Document getRequestDocument() {
 
 		if (_document.get() == null) {
+			String content = _content.get();
+			if(content == null){
+				return null;
+			}
 			try {
-				setRequestDocument(SAXReaderUtil.read(_content.get()));
+				setRequestDocument(SAXReaderUtil.read(content));
 			}
 			catch (DocumentException e) {
 				_log.error(e);


### PR DESCRIPTION
Caused by: java.lang.NullPointerException
    at com.liferay.portal.kernel.io.unsync.UnsyncStringReader.<init>(UnsyncStringReader.java:34)
    at com.liferay.util.xml.XMLSafeReader.<init>(XMLSafeReader.java:25)
    at com.liferay.portal.xml.SAXReaderImpl.read(SAXReaderImpl.java:437)
    at com.liferay.portal.kernel.xml.SAXReaderUtil.read(SAXReaderUtil.java:155)
    at it.smc.calendar.sync.caldav.CalDAVRequestThreadLocal.getRequestDocument(CalDAVRequestThreadLocal.java:37)
    at it.smc.calendar.sync.caldav.util.CalDAVUtil.getRequestDAVProps(CalDAVUtil.java:188)
    ... 59 more
