### PR TITLE
Fix on report method conditions

### DIFF
--- a/modules/caldav-sync/caldav-sync-web/src/main/java/it/smc/calendar/caldav/sync/methods/ReportMethodImpl.java
+++ b/modules/caldav-sync/caldav-sync-web/src/main/java/it/smc/calendar/caldav/sync/methods/ReportMethodImpl.java
@@ -104,8 +104,7 @@ public class ReportMethodImpl extends PropfindMethodImpl {
 			CalDAVRequestThreadLocal.getRequestDocument().selectNodes(
 				"//*[local-name()='href']");
 
-		if ((hrefNodes.size() > 0) &&
-			CalDAVUtil.isCalendarBookingRequest(webDAVRequest)) {
+		if (hrefNodes.size() > 0) {
 
 			calendarBookings = new ArrayList<>();
 


### PR DESCRIPTION
- If the request body contains some href nodes, makes sense to respond promptly with the requested resources.
- Fixes the issue #12, because on every chunk request, the response contained all events.